### PR TITLE
Small bug in RootManager.destroyRoot

### DIFF
--- a/src/haxe/ui/toolkit/core/RootManager.hx
+++ b/src/haxe/ui/toolkit/core/RootManager.hx
@@ -57,13 +57,8 @@ class RootManager {
 	}
 	
 	public function destroyRoot(root:Root):Void {
-		var options:Dynamic = null;
-		if (options == null) {
-			options = { };
-		}
-
-		options.parent = (options.parent != null) ? options.parent : Lib.current.stage;
-		options.parent.removeChild(root.sprite);
+		if (root.sprite.parent != null)
+			root.sprite.parent.removeChild(root.sprite);
 		root.dispose();
 		
 		_roots.remove(root);


### PR DESCRIPTION
Hi,
I found this bug while integrating HaxeUI in my game:
- Fixed RootManager.destroyRoot to include support to any root parents instead of only the OpenFL Stage

Best
