### PR TITLE
Added support for embedded fonts

### DIFF
--- a/src/haxe/ui/toolkit/core/Macros.hx
+++ b/src/haxe/ui/toolkit/core/Macros.hx
@@ -47,7 +47,7 @@ class Macros {
 				var props:Array<String> = styleData.split(":");
 				var propName:String = StringTools.trim(props[0]);
 				var propValue:String = StringTools.trim(props[1]);
-				if (ScriptUtils.isScript(propValue) && propName != "filter" && propName != "icon" && propName != "backgroundImage") {
+				if (ScriptUtils.isScript(propValue) && propName != "filter" && propName != "icon" && propName != "backgroundImage" && propName != "fontName") {
 					dynamicValues.set(propName, propValue);
 					continue;
 				}

--- a/src/haxe/ui/toolkit/text/TextDisplay.hx
+++ b/src/haxe/ui/toolkit/text/TextDisplay.hx
@@ -80,6 +80,7 @@ class TextDisplay implements ITextDisplay {
 		var format:TextFormat = _tf.getTextFormat();
 		if (_style.fontName != null) {
 			format.font = _style.fontName;
+			_tf.embedFonts = true;
 		}
 		if (_style.fontSize != -1) {
 			format.size = _style.fontSize;


### PR DESCRIPTION
Hi Ian,

I found a couple of bugs trying to use embedded fonts

This syntax was breaking the macro parser:
fontName: "assets/fonts/example.ttf";
This patch should fix the issue.

Best
