### PR TITLE
Adding toString to ListViewItem

### DIFF
--- a/src/haxe/ui/toolkit/containers/ListView.hx
+++ b/src/haxe/ui/toolkit/containers/ListView.hx
@@ -385,6 +385,10 @@ class ListViewItem extends StateComponent {
 		addEventListener(MouseEvent.CLICK, _onMouseClick);
 	}
 	
+	public function toString():String {
+		return text;
+	}
+
 	//******************************************************************************************
 	// Event handlers
 	//******************************************************************************************


### PR DESCRIPTION
I added the toString method to ListViewItem. My application crashed when trying to trace a ListViewItem from List.selectedItems and rather than always remember to use item.text I figured this was easier.
