### PR TITLE
Add attributes to make Text selectable & mouseEnabled

### DIFF
--- a/src/haxe/ui/toolkit/controls/Text.hx
+++ b/src/haxe/ui/toolkit/controls/Text.hx
@@ -98,6 +98,10 @@ class Text extends StateComponent implements IClonable<Text> {
 	public var multiline(get, set):Bool;
 	@:clonable
 	public var wrapLines(get, set):Bool;
+	@:clonable
+	public var selectable(get, set):Bool;
+	@:clonable
+	public var mouseEnabled(get, set):Bool;
 	
 	private function get_multiline():Bool {
 		return _textDisplay.multiline;
@@ -115,5 +119,21 @@ class Text extends StateComponent implements IClonable<Text> {
 	private function set_wrapLines(value:Bool):Bool {
 		_textDisplay.wrapLines = value;
 		return value;
+	}
+	
+	private function get_selectable():Bool {
+		return _textDisplay.selectable;
+	}
+	
+	private function set_selectable(value:Bool):Bool {
+		return _textDisplay.selectable = value;
+	}
+	
+	private function get_mouseEnabled():Bool {
+		return _textDisplay.mouseEnabled;
+	}
+	
+	private function set_mouseEnabled(value:Bool):Bool {
+		return _textDisplay.mouseEnabled = value;
 	}
 }

--- a/src/haxe/ui/toolkit/text/ITextDisplay.hx
+++ b/src/haxe/ui/toolkit/text/ITextDisplay.hx
@@ -12,4 +12,6 @@ interface ITextDisplay {
 	public var wrapLines(get, set):Bool;
 	public var displayAsPassword(get, set):Bool;
 	public var visible(get, set):Bool;
+	public var selectable(get, set):Bool;
+	public var mouseEnabled(get, set):Bool;
 }

--- a/src/haxe/ui/toolkit/text/TextDisplay.hx
+++ b/src/haxe/ui/toolkit/text/TextDisplay.hx
@@ -41,6 +41,8 @@ class TextDisplay implements ITextDisplay {
 	public var wrapLines(get, set):Bool;
 	public var displayAsPassword(get, set):Bool;
 	public var visible(get, set):Bool;
+	public var selectable(get, set):Bool;
+	public var mouseEnabled(get, set):Bool;
 
 	private function get_text():String {
 		return _tf.text;
@@ -170,5 +172,21 @@ class TextDisplay implements ITextDisplay {
 	private function set_visible(value:Bool):Bool {
 		_tf.visible = value;
 		return value;
+	}
+	
+	private function get_selectable():Bool {
+		return _tf.selectable;
+	}
+	
+	private function set_selectable(value:Bool):Bool {
+		return _tf.selectable = value;
+	}
+	
+	private function get_mouseEnabled():Bool {
+		return _tf.mouseEnabled;
+	}
+	
+	private function set_mouseEnabled(value:Bool):Bool {
+		return _tf.mouseEnabled = value;
 	}
 }


### PR DESCRIPTION
Be sure to review my code, I've been using HaxeUI only since this morning and I don't know the scope of this changes or if it's the right way to do it.

Tested in XML with this `<Text text="Long Selectable Title" selectable="true" mouseEnabled="true" />`, it worked fine.
