### PR TITLE
Fix click handler on simple popups with more than one custom button.... 

### DIFF
--- a/src/haxe/ui/toolkit/controls/popups/Popup.hx
+++ b/src/haxe/ui/toolkit/controls/popups/Popup.hx
@@ -100,7 +100,7 @@ class Popup extends VBox implements IDraggable {
 			var buttons:Array<PopupButtonInfo> = cast _config.buttons;
 			_buttonBar.addChild(box);
 			for (info in buttons) {
-				if (info.type != PopupButton.CUSTOM) {
+				if (info.type & PopupButton.CUSTOM != PopupButton.CUSTOM) {
 					var button:Button = createStandardButton(info.type);
 					if (button != null) {
 						box.addChild(button);
@@ -109,7 +109,7 @@ class Popup extends VBox implements IDraggable {
 					var button:Button = new Button();
 					button.text = info.text;
 					button.addEventListener(MouseEvent.CLICK, function(e) {
-						clickButton(PopupButton.CUSTOM);
+						clickButton(info.type);
 					});
 					box.addChild(button);
 				}


### PR DESCRIPTION
Check for the Popup.Button.CUSTOM flag _within_ item.type and not a strict equality between PopupButton.CUSTOM and the item.type

So the callback on this works...

PopupManager.instance.showSimple("Choose!", "Pick an option", [
    { type:PopupButton.CUSTOM, text:'Custom 1' },
    { type:PopupButton.CUSTOM + 1, text:'Custom 2' }
], handler);

...

function handler(flag) {
    trace(flag==PopupButton.CUSTOM);
    trace(flag==PopupButton.CUSTOM+1);
}
