### PR TITLE
added functionality allowing to process all "text" fields in xml

### DIFF
--- a/src/haxe/ui/toolkit/core/Toolkit.hx
+++ b/src/haxe/ui/toolkit/core/Toolkit.hx
@@ -62,6 +62,11 @@ class Toolkit {
 	//******************************************************************************************
 	public static var useDefaultTheme(default, default):Bool = true;
 	public static var theme(default, default):Theme;
+
+	//******************************************************************************************
+	// Text translator for xml. All "text" attributes in xml are processed by this function.
+	//******************************************************************************************
+    public static var xmlTextTranslator(default,default):String -> String;
 	
 	//******************************************************************************************
 	// Processes a chunk of xml, return values depend on what comes in, could return IDisplayObject, IDataSource

--- a/src/haxe/ui/toolkit/core/xml/UIProcessor.hx
+++ b/src/haxe/ui/toolkit/core/xml/UIProcessor.hx
@@ -1,6 +1,7 @@
 package haxe.ui.toolkit.core.xml;
 
 import haxe.ui.toolkit.core.ClassManager;
+import haxe.ui.toolkit.core.Toolkit;
 import haxe.ui.toolkit.core.Component;
 import haxe.ui.toolkit.core.interfaces.IDataComponent;
 import haxe.ui.toolkit.core.interfaces.IDisplayObject;
@@ -46,6 +47,10 @@ class UIProcessor extends XMLProcessor {
 				className = directionalClassName;
 			}
 		}
+        var text:String = node.get("text");
+        if (text != null && Toolkit.xmlTextTranslator != null) {
+          node.set("text",Toolkit.xmlTextTranslator(text));
+        }
 		if (className != null) {
 			result = createComponent(className, node);
 		}

--- a/src/haxe/ui/toolkit/data/DataSource.hx
+++ b/src/haxe/ui/toolkit/data/DataSource.hx
@@ -3,6 +3,7 @@ package haxe.ui.toolkit.data;
 import flash.events.Event;
 import flash.events.EventDispatcher;
 import haxe.ui.toolkit.core.interfaces.IEventDispatcher;
+import haxe.ui.toolkit.core.Toolkit;
 import haxe.ui.toolkit.resources.ResourceManager;
 
 class DataSource extends EventDispatcher implements IDataSource implements IEventDispatcher {
@@ -77,6 +78,9 @@ class DataSource extends EventDispatcher implements IDataSource implements IEven
 	public function add(o:Dynamic):Bool {
 		var b:Bool = false;
 		if (allowAdditions) {
+            if (Toolkit.xmlTextTranslator != null && o.text != null) {
+              o.text = Toolkit.xmlTextTranslator(o.text);
+            }
 			b = _add(o);
 			if (b == true) {
 				dispatchChanged();
@@ -88,6 +92,9 @@ class DataSource extends EventDispatcher implements IDataSource implements IEven
 	public function update(o:Dynamic):Bool {
 		var b:Bool = false;
 		if (allowUpdates) {
+            if (Toolkit.xmlTextTranslator != null && o.text != null) {
+              o.text = Toolkit.xmlTextTranslator(o.text);
+            }
 			b = _update(o);
 			if (b) {
 				dispatchChanged();


### PR DESCRIPTION
This is a suggestion of how to get internationalization with firetongue to work with haxeui. The Idea is:

``` haxe
    Toolkit.xmlTextTranslator = function(t:String) {firetongue.get(t);}
    Toolkit.init();
```

Now all xml that is loaded is checked for ".text" fields, which are than translated by the set function.

I do not know if I have choosen the best places to insert this, or function names. So feel free to reject this pull request.
But it would be nice if something like this could be integrated into haxeui ...
