### PR TITLE
Stack

### DIFF
--- a/src/haxe/ui/toolkit/containers/Stack.hx
+++ b/src/haxe/ui/toolkit/containers/Stack.hx
@@ -14,6 +14,9 @@ class Stack extends Component {
 	private var _selectedIndex:Int = -1;
 	#end
 	
+    // History of selected children
+    private var _history : List<Int> = new List();
+
 	//private var _transition:String = "slide";
 	
 	public function new() {
@@ -97,6 +100,8 @@ class Stack extends Component {
 					}
 				}
 			}
+            // Remember in history
+            _history.push(_selectedIndex);
 			_selectedIndex = value;
 			
 			var event:Event = new Event(Event.CHANGE);
@@ -104,4 +109,15 @@ class Stack extends Component {
 		}
 		return value;
 	}
+
+    // Go back to the last selected index
+    public function back() {
+      var last = _history.pop();
+      if (last == null) {
+        return;
+      }
+      set_selectedIndex(last);
+      // Remove the just added history
+      _history.pop();
+    }
 }


### PR DESCRIPTION
First commit:
In my opinion, screens should slide from right to left when going forward.

Second commit:
Added history for recent shown screen, so that one can got back to the last screen without remembering which it was.
