### PR TITLE
Bugfix, remove segfault when null value is set for icon and _icon==null

### DIFF
--- a/src/haxe/ui/toolkit/controls/Button.hx
+++ b/src/haxe/ui/toolkit/controls/Button.hx
@@ -132,7 +132,9 @@ class Button extends StateComponent implements IFocusable implements IClonable<S
 			_icon.resource = value;
 			organiseChildren();
 		} else {
-			_icon.visible = false;
+            if (_icon != null) {
+			    _icon.visible = false;
+            }
 		}
 		return value;
 	}


### PR DESCRIPTION
This bug occurs when cloning buttons
