### PR TITLE
Auto size the content of the simple popup content, so that the text is not overdrawn by the buttons

### DIFF
--- a/src/haxe/ui/toolkit/controls/popups/SimplePopupContent.hx
+++ b/src/haxe/ui/toolkit/controls/popups/SimplePopupContent.hx
@@ -16,7 +16,7 @@ class SimplePopupContent extends PopupContent {
 		_textControl.wrapLines = true;
 		_textControl.percentWidth = 100;
 		_textControl.text = text;
-		_textControl.autoSize = false;
+		_textControl.autoSize = true;
 	}
 	
 	//******************************************************************************************


### PR DESCRIPTION
On mobile devices, when increasing the text size, the simple popup does not scale correctly so that the content is to small for the text. This patch fixes this for me.
