### PR TITLE
Remove preferredSDK from haxeui.hxproj

### DIFF
--- a/haxeui.hxproj
+++ b/haxeui.hxproj
@@ -12,7 +12,6 @@
     <movie minorVersion="0" />
     <movie platform="NME" />
     <movie background="FFFFFF" />
-    <movie preferredSDK=";3;" />
   </output>
   <!-- Other classes to be compiled into your SWF -->
   <classpaths>


### PR DESCRIPTION
FD displays a warning sign next to the project properties otherwise (unless you're still using Haxe 3.0, that is).

![](http://i.imgur.com/GV3NbmH.png)

![](http://i.imgur.com/YwNcTft.png)
