### PR TITLE
Dismissing modal popups

### DIFF
--- a/haxe/ui/toolkit/controls/popups/Popup.hx
+++ b/haxe/ui/toolkit/controls/popups/Popup.hx
@@ -69,6 +69,11 @@ class Popup extends VBox implements IDraggable {
 		if (_config.styleName != null) {
 			this.styleName = _config.styleName;
 		}
+		if (_config.dismiss & Dismiss.CLICK_INSIDE > 0)
+			addEventListener(MouseEvent.CLICK, function(e) {
+				PopupManager.instance.hidePopup(this);
+				callClosingCallback(PopupButton.CANCEL);
+			});
 		
 		_fn = fn;
 	}
@@ -218,5 +223,10 @@ class Popup extends VBox implements IDraggable {
 		if (_fn != null) {
 			_fn(button);
 		}
+	}
+	
+	public function callClosingCallback(button:Dynamic) {
+		if (_fn != null)
+			_fn(button);
 	}
 }

--- a/haxe/ui/toolkit/core/Root.hx
+++ b/haxe/ui/toolkit/core/Root.hx
@@ -1,5 +1,6 @@
 package haxe.ui.toolkit.core;
 
+import haxe.ui.toolkit.core.PopupManager.Dismiss;
 import openfl.events.Event;
 import openfl.events.MouseEvent;
 import openfl.geom.Point;
@@ -86,6 +87,9 @@ class Root extends Component {
 			_modalOverlay = new Component();
 			_modalOverlay.id = "modalOverlay";
 			_modalOverlay.percentWidth = _modalOverlay.percentHeight = 100;
+			_modalOverlay.onClick = function(e) {
+				PopupManager.instance.dismissModal(Dismiss.CLICK_OUTSIDE);
+			};
 		}
 		if (findChild("modalOverlay") == null) {
 			addChild(_modalOverlay);


### PR DESCRIPTION
To close #93.
You can control how a popup can be dismissed by setting the "dismiss" config property to one or more of the followin flags defined in the Dismiss class:

ESCAPE - Press escape.
ANYKEY - Press any key.
CLICK_OUTSIDE - Click outside the popup (on the modal overlay).
CLICK_INSIDE - Click on the popup.
CLICK - Click anywhere.

If more than one modal popup is visible at the same time, all actions except CLICK_INSIDE will try to close the most recently created.

The callback function will be called with PopupButton.CANCEL as argument.