### PR TITLE
added: image smoothing to Image controls

### DIFF
--- a/haxe/ui/toolkit/controls/Image.hx
+++ b/haxe/ui/toolkit/controls/Image.hx
@@ -191,6 +191,7 @@ class Image extends Component implements IClonable<Image> {
 	private function updateGif(gif:Gif):Void {
 		var player:GifPlayer = new GifPlayer(gif);
 		_gifWrapper = new GifPlayerWrapper(player);
+		_gifWrapper.smoothing = true;
 		updateContent();
 	}
 	#end
@@ -243,6 +244,7 @@ class Image extends Component implements IClonable<Image> {
 	
 	private function updateBitmap(bmpData:BitmapData):Void {
 		_bmp = new Bitmap(bmpData);
+		_bmp.smoothing = true;
 		updateContent();
 	}
 


### PR DESCRIPTION
Images currently pixelate when enlarged and "sparkle" when shrunk, so I've enabled filtering. This seems a better sensible default, and shouldn't add any additional performance overhead.
(Note that they'll still sparkle when shrunk below 50% size, cos there's no mipmaps)