### PR TITLE
fixed: the first tap after an inertial scroll was ignored and autoHideScrolls was not working

### DIFF
--- a/haxe/ui/toolkit/containers/ScrollView.hx
+++ b/haxe/ui/toolkit/containers/ScrollView.hx
@@ -331,7 +331,7 @@ class ScrollView extends StateComponent {
 		if (content != null) {
 
 			_inertiaSpeed.x *= 0.8;
-	  	_inertiaSpeed.y *= 0.8;
+			_inertiaSpeed.y *= 0.8;
 
 			if ((content.width > layout.usableWidth || _virtualScrolling == true)) {
 				if (_showHScroll == true && _autoHideScrolls == true) {
@@ -351,8 +351,16 @@ class ScrollView extends StateComponent {
 				}
 			}
 
-	  	if ( Math.abs(_inertiaSpeed.x) < 0.1 && Math.abs(_inertiaSpeed.y) < 0.1 )
-	  		Screen.instance.removeEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
+			if ( Math.abs(_inertiaSpeed.x) < 0.1 && Math.abs(_inertiaSpeed.y) < 0.1 ){
+				_eventTarget.visible = false;
+				if (_hscroll != null && _showHScroll == true && _autoHideScrolls == true) {
+					_hscroll.visible = false;
+				}
+				if (_vscroll != null && _showVScroll == true && _autoHideScrolls == true) {
+					_vscroll.visible = false;
+				}
+				Screen.instance.removeEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
+			}
 		}
 	}
 	


### PR DESCRIPTION
When you did a quick scroll on mobile and then tapped on a control, the first tap was always ignored, the scrollbars remained onscreen, even when autohide was enabled.