### PR TITLE
fixed: Buttons with multiline labels did not always vertically align correctly

### DIFF
--- a/haxe/ui/toolkit/controls/Button.hx
+++ b/haxe/ui/toolkit/controls/Button.hx
@@ -171,7 +171,7 @@ class Button extends StateComponent implements IFocusable implements IClonable<S
 		if (autoSize == false || percentWidth > 0) {
 			if (_label != null) {
 				_label.percentWidth = 100;
-				_label.autoSize = false;
+				_label.autoSize = _multiline; //if multiline maintain autoSize so Text has the correct height
 			}
 		}
 		


### PR DESCRIPTION
Text objects can sometimes be taller than their DisplayObjects when they're multiline/wordWrap, due the TextField sizing before the correct styling has been assigned, and Buttons then locking the Text height before the TextField is recalculated with the correct height. This can
lead to extra vertical space below button labels. autoSize should always be left on to correct for this.

(Note also the modified code is for width constraint, but autoSize only affects height when TextFields have wordWrap)