### PR TITLE
added: wrapLines property to checkboxes

### DIFF
--- a/haxe/ui/toolkit/controls/CheckBox.hx
+++ b/haxe/ui/toolkit/controls/CheckBox.hx
@@ -78,6 +78,15 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 		}
 		return newValue;
 	}
+
+	private override function get_height():Float {
+		var height = super.get_height();
+		if(autoSize){
+			return height;
+		}else{
+			return Math.max(height, _label.height);
+		}
+	}
 	
 	//******************************************************************************************
 	// Component getters/setters

--- a/haxe/ui/toolkit/controls/CheckBox.hx
+++ b/haxe/ui/toolkit/controls/CheckBox.hx
@@ -20,12 +20,12 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 	
 	public function new() {
 		super();
-		autoSize = true;
 		sprite.buttonMode = true;
 		sprite.useHandCursor = true;
 		_value = new CheckBoxValue();
 		_label = new Text();
 		layout = new HorizontalLayout();
+		autoSize = true;
 	}
 
 	//******************************************************************************************
@@ -35,7 +35,6 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 		super.initialize();
 
 		_value.verticalAlign = VerticalAlign.CENTER;
-		_label.percentWidth = 100;
 		addChild(_value);
 		addChild(_label);
 		
@@ -51,6 +50,12 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 	//******************************************************************************************
 	// Component overrides
 	//******************************************************************************************
+	private override function set_autoSize(value:Bool):Bool {
+		value = super.set_autoSize(value);
+		_label.percentWidth = value?-1:100;
+		return value;
+	}
+
 	private override function get_text():String {
 		return _label.text;
 	}

--- a/haxe/ui/toolkit/controls/CheckBox.hx
+++ b/haxe/ui/toolkit/controls/CheckBox.hx
@@ -100,8 +100,7 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 	}
 	
 	private function set_multiline(value:Bool):Bool {
-		_label.multiline = value;
-		return value;
+		return _label.multiline = value;
 	}
 
 	private function get_wrapLines():Bool {
@@ -109,8 +108,7 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 	}
 	
 	private function set_wrapLines(value:Bool):Bool {
-		_label.wrapLines = value;
-		return value;
+		return _label.wrapLines = value;
 	}
 	
 	private function get_selected():Bool {

--- a/haxe/ui/toolkit/controls/CheckBox.hx
+++ b/haxe/ui/toolkit/controls/CheckBox.hx
@@ -35,6 +35,7 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 		super.initialize();
 
 		_value.verticalAlign = VerticalAlign.CENTER;
+		_label.percentWidth = 100;
 		addChild(_value);
 		addChild(_label);
 		
@@ -77,10 +78,35 @@ class CheckBox extends Component implements IClonable<CheckBox> {
 	// Component getters/setters
 	//******************************************************************************************
 	/**
+	 Defines whether or not the text can span more than a single line
+	 **/
+	@:clonable
+	public var multiline(get, set):Bool;
+	@:clonable
+	public var wrapLines(get, set):Bool;
+	/**
 	 Defines whether the checkbox is checked or not
 	 **/
 	@:clonable
 	public var selected(get, set):Bool;
+
+	private function get_multiline():Bool {
+		return _label.multiline;
+	}
+	
+	private function set_multiline(value:Bool):Bool {
+		_label.multiline = value;
+		return value;
+	}
+
+	private function get_wrapLines():Bool {
+		return _label.wrapLines;
+	}
+	
+	private function set_wrapLines(value:Bool):Bool {
+		_label.wrapLines = value;
+		return value;
+	}
 	
 	private function get_selected():Bool {
 		return _selected;


### PR DESCRIPTION
Because checkboxes deserve multiline and wrapLines love too.

This is designed to be used with autoSize=false, and a set width.

I haven't fully tested this in all layout scenarios, buut I think it should be good.