### PR TITLE
fixed: Checkbox labels weren't clickable

### DIFF
--- a/haxe/ui/toolkit/text/TextDisplay.hx
+++ b/haxe/ui/toolkit/text/TextDisplay.hx
@@ -27,7 +27,7 @@ class TextDisplay implements ITextDisplay {
 		_tf.type = TextFieldType.DYNAMIC;
 		_tf.selectable = false;
 		_tf.multiline = false;
-		_tf.mouseEnabled = false;
+		_tf.mouseEnabled = true;
 		_tf.wordWrap = false;
 		_tf.autoSize = TextFieldAutoSize.LEFT;
 		_tf.text = "";
@@ -134,7 +134,7 @@ class TextDisplay implements ITextDisplay {
 		} else {
 			_tf.type = TextFieldType.DYNAMIC;
 			_tf.selectable = false;
-			_tf.mouseEnabled = false;
+			_tf.mouseEnabled = true;
 		}
 		return value;
 	}


### PR DESCRIPTION
Textfields aren't clickable so the label click event on Checkboxes wasn't firing. (I'm guessing it did at some point in time, but it's borked now :/) I've made all Text report mouse events for now.

I could have used the `interactive` property, but that would have made the text editable, too.

Checkboxes without clickable labels are very sad, and especially awkward on mobile :(