### PR TITLE
Throw meaningful exception when image resource was not found

### DIFF
--- a/haxe/ui/toolkit/controls/Image.hx
+++ b/haxe/ui/toolkit/controls/Image.hx
@@ -238,7 +238,10 @@ class Image extends Component implements IClonable<Image> {
 				r.request();
 			#end
 		} else {
-			callback(ResourceManager.instance.getBitmapData(res));
+			var data = ResourceManager.instance.getBitmapData(res);
+			if (data == null)
+				throw 'Image [$res] not found!';
+			callback(data);
 		}
 	}
 	


### PR DESCRIPTION
Instead of this obscure error message:

    Invalid field access : get_width
    Called from haxe.ui.toolkit.controls.Image::updateContent line 330
    Called from haxe.ui.toolkit.controls.Image::initialize line 59
    Called from haxe.ui.toolkit.core.DisplayObject::_onAddedToStage line 84
    Called from openfl._legacy.events.EventDispatcher::dispatchEvent line 98

This will be thrown now:

    Image [themes/shared/arrow_up.png] not found!
    Called from haxe.ui.toolkit.controls.Image::loadBitmap line 243
    Called from haxe.ui.toolkit.controls.Image::set_resource line 163
    Called from haxe.ui.toolkit.controls.Button::set_icon line 150
    Called from haxe.ui.toolkit.controls.Button::applyStyle line 667
    Called from haxe.ui.toolkit.core.StyleableDisplayObject::refreshStyle line 323
    Called from haxe.ui.toolkit.core.StyleableDisplayObject::preInitialize line 31
    Called from haxe.ui.toolkit.controls.Button::preInitialize line 271
    Called from haxe.ui.toolkit.core.DisplayObject::_onAddedToStage line 82
    Called from openfl._legacy.events.EventDispatcher::dispatchEvent line 98


