### PR TITLE
Better error reporting when class is not found

### DIFF
--- a/haxe/ui/toolkit/console/HaxeUIConsoleFunctions.hx
+++ b/haxe/ui/toolkit/console/HaxeUIConsoleFunctions.hx
@@ -9,6 +9,7 @@ import haxe.ui.toolkit.core.PopupManager;
 import haxe.ui.toolkit.core.RootManager;
 import haxe.ui.toolkit.resources.ResourceManager;
 import haxe.ui.toolkit.util.Identifier;
+import haxe.ui.toolkit.util.Types;
 import pgr.dconsole.DC;
 import pgr.dconsole.DCCommands;
 
@@ -24,13 +25,13 @@ class HaxeUIConsoleFunctions {
 		DC.registerFunction(listScripts, "listScripts");
 		DC.registerFunction(removeScript, "removeScript");
 	}
-	
+
 	public static function create(type:String, text:String = null, id:String = null, width:Float = -1, height:Float = -1, x:Float = -1, y:Float = -1):Component {
 		var comp:Component = null;
 		if (type != null) {
 			var className:String = ClassManager.instance.getComponentClassName(type);
 			if (className != null) {
-				comp = Type.createInstance(Type.resolveClass(className), []);
+				comp = Type.createInstance(Types.resolveClass(className), []);
 				if (id == null) {
 					id = Identifier.createObjectId(comp);
 					id = id.substr(id.lastIndexOf(".") + 1, id.length).toLowerCase();
@@ -38,14 +39,14 @@ class HaxeUIConsoleFunctions {
 				if (text == null) {
 					text = id;
 				}
-				
+
 				if (width == -1) {
 					width = 100;
 				}
 				if (height == -1) {
 					height = 100;
 				}
-				
+
 				comp.id = id;
 				comp.text = text;
 				if (width  != -1) {
@@ -55,14 +56,14 @@ class HaxeUIConsoleFunctions {
 					comp.height = height;
 				}
 				RootManager.instance.currentRoot.addChild(comp);
-				
+
 				DC.logConfirmation("Created '" + id + "'");
 				DC.registerObject(comp, id);
 			}
 		}
 		return comp;
 	}
-	
+
 	public static function dispose(target:Dynamic):Void {
 		var c:Component = getComponent(target);
 		if (c != null) {
@@ -70,7 +71,7 @@ class HaxeUIConsoleFunctions {
 			c.parent.removeChild(c);
 		}
 	}
-	
+
 	public static function inspect(target:Dynamic, verbose:Bool = false):Void {
 		var c:Component = getComponent(target);
 		if (c != null) {
@@ -93,11 +94,11 @@ class HaxeUIConsoleFunctions {
 			DC.logError(target + " is not a haxeui component");
 			return null;
 		}
-		
+
 		var c:Component = cast obj;
 		return c;
 	}
-	
+
 	private static function inspectComponent(c:Component, indent:Int, verbose:Bool = false):Void {
 		var s:String = "";
 		var n:Int = indent - 1;
@@ -109,7 +110,7 @@ class HaxeUIConsoleFunctions {
 			} else {
 				arr.push(" │ ");
 			}
-			
+
 			n--;
 			t = cast t.parent;
 		}
@@ -161,18 +162,18 @@ class HaxeUIConsoleFunctions {
 				s += " [" + verboseDetails.join(", ") + "]";
 			}
 		}
-		
+
 		DC.logInfo(s);
 		for (child in c.children) {
 			inspectComponent(cast child, indent + 1, verbose);
 		}
 	}
-	
+
 	private static function isLastChild(c:Component):Bool {
 		var index:Int = c.parent.indexOfChild(c);
 		return (index == c.parent.numChildren - 1);
 	}
-	
+
 	public static function runScript(scriptRes:String):Void {
 		var scriptData:String = getScriptData(scriptRes);
 		if (scriptData == null) {
@@ -183,7 +184,7 @@ class HaxeUIConsoleFunctions {
 		scriptData = scriptData.substr(0, n);
 		DC.instance.commands.evaluate(scriptData);
 	}
-	
+
 	public static function viewScript(scriptRes:String):Void {
 		var scriptData:String = getScriptData(scriptRes);
 		if (scriptData == null) {
@@ -210,14 +211,14 @@ class HaxeUIConsoleFunctions {
 			}
 		});
 	}
-	
+
 	public static function editScript(scriptRes:String):Void {
 		var scriptData:String = getScriptData(scriptRes);
 		if (scriptData == null) {
 			DC.logError("Script '" + scriptRes + "' not found");
 			return;
 		}
-		
+
 		var config:Dynamic = {
 			width: 500,
 			buttons: PopupButton.CANCEL | PopupButton.CONFIRM,
@@ -228,22 +229,22 @@ class HaxeUIConsoleFunctions {
 			}
 		});
 	}
-	
+
 	public static function removeScript(scriptRes:String):Void {
 		if (HaxeUIConsole.scripts.exists(scriptRes) == false) {
 			DC.logError("'" + scriptRes + "' doesnt exist");
 			return;
 		}
-		
+
 		HaxeUIConsole.scripts.remove(scriptRes);
 	}
-	
+
 	public static function listScripts():Void {
 		for (r in HaxeUIConsole.scripts.keys()) {
 			DC.logInfo(r);
 		}
 	}
-	
+
 	private static function getScriptData(scriptRes:String):String {
 		var scriptData:String = null;
 		if (HaxeUIConsole.scripts.exists(scriptRes)) {
@@ -253,21 +254,21 @@ class HaxeUIConsoleFunctions {
 		}
 		return scriptData;
 	}
-	
+
 	private static function setScriptData(scriptRes:String, scriptData:String):Void {
 		HaxeUIConsole.scripts.set(scriptRes, scriptData);
 		DC.logConfirmation("Script '" + scriptRes + "' saved");
 	}
-	
+
 	private static function unregisterObjects(parent:Component):Void {
 		if (parent == null) {
 			return;
 		}
-		
+
 		if (parent.id != null) {
 			DC.unregisterObject(parent.id);
 		}
-		
+
 		for (child in parent.children) {
 			unregisterObjects(cast child);
 		}

--- a/haxe/ui/toolkit/containers/ListView.hx
+++ b/haxe/ui/toolkit/containers/ListView.hx
@@ -16,21 +16,22 @@ import haxe.ui.toolkit.core.StyleableDisplayObject;
 import haxe.ui.toolkit.data.ArrayDataSource;
 import haxe.ui.toolkit.data.IDataSource;
 import haxe.ui.toolkit.events.UIEvent;
+import haxe.ui.toolkit.util.Types;
 
 @:build(haxe.ui.toolkit.core.Macros.addEvents([
 	"componentEvent"
 ]))
 class ListView extends ScrollView implements IDataComponent {
 	private var _dataSource:IDataSource;
-	
+
 	private var _content:VBox;
-	
+
 	private var _selectedItems:Array<IItemRenderer>;
 	private var _lastSelection:Int = -1;
-	
+
 	private var _itemRenderer:Dynamic;
 	private var _allowSelection= true;
-	
+
 	public function new() {
 		super();
 		autoSize = false;
@@ -53,9 +54,9 @@ class ListView extends ScrollView implements IDataComponent {
 		if (_dataSource == null) { // create a default data source
 			dataSource = new ArrayDataSource();
 		}
-		
+
 		_dataSource.open();
-		
+
 		syncUI();
 		checkScrolls();
 	}
@@ -64,20 +65,20 @@ class ListView extends ScrollView implements IDataComponent {
 		if (!_ready || _invalidating) {
 			return;
 		}
-		
+
 		super.invalidate(type, recursive);
 		if (type & InvalidationFlag.DATA == InvalidationFlag.DATA) {
 			syncUI();
 		}
 	}
-	
+
 	public override function dispose():Void {
 		if (_dataSource != null) {
 			_dataSource.close();
 		}
 		super.dispose();
 	}
-	
+
 	public override function addChild(child:IDisplayObject):IDisplayObject {
 		if (Std.is(child, IItemRenderer)) {
 			_itemRenderer = child;
@@ -89,7 +90,7 @@ class ListView extends ScrollView implements IDataComponent {
 	public override function addChildAt(child:IDisplayObject, index:Int):IDisplayObject {
 		return super.addChildAt(child, index);
 	}
-	
+
 	//******************************************************************************************
 	// Instance properties
 	//******************************************************************************************
@@ -100,11 +101,11 @@ class ListView extends ScrollView implements IDataComponent {
 	public var content(get, null):Component;
 	public var itemRenderer(get, set):Dynamic;
 	public var allowSelection(get, set):Bool;
-	
+
 	private function get_listSize():Int {
 		return _content.children.length;
 	}
-	
+
 	private function get_itemHeight():Float {
 		if (_content.children.length == 0) {
 			return 0;
@@ -124,11 +125,11 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 		return (cy / n);
 	}
-	
+
 	public function getItem(index:Int):IItemRenderer {
 		return cast(_content.children[index], IItemRenderer);
 	}
-	
+
 	private function get_selectedItems():Array<IItemRenderer> {
 		return _selectedItems;
 	}
@@ -140,7 +141,7 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 		return index;
 	}
-	
+
 	private function set_selectedIndex(value:Int):Int {
 		if (_ready == false) {
 			return value;
@@ -159,10 +160,10 @@ class ListView extends ScrollView implements IDataComponent {
 				}
 			}
 		}
-		
+
 		return value;
 	}
-	
+
 	private function get_content():Component {
 		var c:Component = null;
 		if (numChildren > 0) {
@@ -170,47 +171,47 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 		return c;
 	}
-	
+
 	private function get_itemRenderer():Dynamic {
 		return _itemRenderer;
 	}
-	
+
 	private function set_itemRenderer(value:Dynamic):Dynamic {
 		_itemRenderer = value;
 		return value;
 	}
-	
+
 	private function get_allowSelection():Bool {
 		return _allowSelection;
 	}
-	
+
 	private function set_allowSelection(value:Bool):Bool {
 		_allowSelection = value;
 		return value;
 	}
-	
+
 	//******************************************************************************************
 	// IDataComponent
 	//******************************************************************************************
 	public var dataSource(get, set):IDataSource;
-	
+
 	private function get_dataSource():IDataSource {
 		return _dataSource;
 	}
-	
+
 	private function set_dataSource(value:IDataSource):IDataSource {
 		if (_dataSource != null) { // clean up if has ds
 			if (Std.is(_dataSource, IEventDispatcher)) {
 				cast(_dataSource, IEventDispatcher).removeEventListener(Event.CHANGE, _onDataSourceChanged);
 			}
 		}
-		
+
 		_dataSource = value;
-		
+
 		if (Std.is(_dataSource, IEventDispatcher)) {
 			cast(_dataSource, IEventDispatcher).addEventListener(Event.CHANGE, _onDataSourceChanged);
 		}
-		
+
 		if (_ready == true) {
 			_content.removeAllChildren();
 			syncUI();
@@ -218,11 +219,11 @@ class ListView extends ScrollView implements IDataComponent {
 		_lastSelection = -1;
 		return value;
 	}
-	
+
 	private function _onDataSourceChanged(event:Event):Void {
 		syncUI();
 	}
-	
+
 	//******************************************************************************************
 	// Add/removes/updates ui items in the underlying scrollview based on the datasource
 	//******************************************************************************************
@@ -237,7 +238,7 @@ class ListView extends ScrollView implements IDataComponent {
 					if (_content.getChildAt(pos) != null) {
 						item = cast(_content.getChildAt(pos), IItemRenderer);
 					}
-					
+
 					if (item == null) { // add item
 						addListViewItem(dataHash, data, pos);
 						pos++;
@@ -253,27 +254,27 @@ class ListView extends ScrollView implements IDataComponent {
 							pos++;
 						}
 					}
-				} while (dataSource.moveNext()); 
+				} while (dataSource.moveNext());
 			}
 		}
-		
+
 		for (n in pos..._content.children.length) { // remove anything left over
 			removeListViewItem(n);
 		}
-		
+
 		var n:Int = 0; // set styles
 		for (child in _content.children) {
 			var item:IItemRenderer = cast(child, IItemRenderer);
 			if (Std.is(item, StyleableDisplayObject) == true && Std.is(item, Divider) == false) {
 				var styleName:String = (n % 2 == 0) ? "even" : "odd";
 				if (!isSelected(item) && cast(item, StyleableDisplayObject).styleName != styleName)  {
-					cast(item, StyleableDisplayObject).styleName = styleName;	
+					cast(item, StyleableDisplayObject).styleName = styleName;
 				}
 			}
 			n++;
 		}
 	}
-	
+
 	private function addListViewItem(dataHash:String, data:Dynamic, index:Int = -1):Void {
 		if (data == null) {
 			return;
@@ -296,7 +297,7 @@ class ListView extends ScrollView implements IDataComponent {
 				cast(item, StyleableDisplayObject).styleName = styleName;
 			}
 		}
-		
+
 		if (item != null) {
 			if (index == -1) {
 				_content.addChild(item);
@@ -304,16 +305,16 @@ class ListView extends ScrollView implements IDataComponent {
 				_content.addChildAt(item, index);
 			}
 		}
-		
+
 		invalidate(InvalidationFlag.SIZE);
-		
+
 		if (data.divider == null || data.divider == false) {
 			cast(item, IDisplayObject).addEventListener(UIEvent.MOUSE_OVER, _onListItemMouseOver);
 			cast(item, IDisplayObject).addEventListener(UIEvent.MOUSE_OUT, _onListItemMouseOut);
 			cast(item, IDisplayObject).addEventListener(UIEvent.CLICK, _onListItemClick);
 		}
 	}
-	
+
 	private function removeListViewItem(index:Int):Void {
 		var item:IItemRenderer = cast(_content.getChildAt(index), IItemRenderer);
 		var sIndex:Int = Lambda.indexOf(_selectedItems, item);
@@ -325,12 +326,12 @@ class ListView extends ScrollView implements IDataComponent {
 			invalidate(InvalidationFlag.SIZE);
 		}
 	}
-	
+
 	private function _onListItemMouseOver(event:UIEvent):Void {
 		if (_allowSelection == false) {
 			return;
 		}
-		
+
 		if (Std.is(event.component, IStateComponent)) {
 			cast(event.component, IStateComponent).state = ItemRenderer.STATE_OVER;
 		}
@@ -340,7 +341,7 @@ class ListView extends ScrollView implements IDataComponent {
 		if (_allowSelection == false) {
 			return;
 		}
-		
+
 		if (Std.is(event.component, IStateComponent)) {
 			var item:IItemRenderer = cast event.component;
 			if (isSelected(item)) {
@@ -350,7 +351,7 @@ class ListView extends ScrollView implements IDataComponent {
 			}
 		}
 	}
-	
+
 	private function _onListItemClick(event:UIEvent):Void {
 		if (_allowSelection == false) {
 			return;
@@ -364,21 +365,21 @@ class ListView extends ScrollView implements IDataComponent {
 			}
 		}
 	}
-	
+
 	private function handleListSelection(item:IItemRenderer, event:UIEvent, raiseEvent:Bool = true):Void {
 		var shiftPressed:Bool = false;
 		var ctrlPressed:Bool = false;
-		
+
 		if (event != null && Std.is(event, MouseEvent)) {
 			var mouseEvent:MouseEvent = cast(event, MouseEvent);
 			shiftPressed = mouseEvent.shiftKey;
 			ctrlPressed = mouseEvent.ctrlKey;
 		}
-		
+
 		if (ctrlPressed == true) {
 			// do nothing
 		} else if (shiftPressed == true) {
-			
+
 		} else {
 			for (selectedItem in _selectedItems) {
 				if (selectedItem != item) {
@@ -387,7 +388,7 @@ class ListView extends ScrollView implements IDataComponent {
 			}
 			_selectedItems = new Array<IItemRenderer>();
 		}
-		
+
 		if (isSelected(item)) {
 			_selectedItems.remove(item);
 			item.state = ItemRenderer.STATE_OVER;
@@ -397,7 +398,7 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 
 		ensureVisible(item);
-		
+
 		if (raiseEvent == true) {
 			if (selectedIndex != -1) {
 				var item:ItemRenderer = cast _content.getChildAt(selectedIndex);
@@ -409,7 +410,7 @@ class ListView extends ScrollView implements IDataComponent {
 			}
 		}
 	}
-	
+
 	private function handleClick(item:IItemRenderer):Void {
 		var index:Int = Lambda.indexOf(_content.children, item);
 		if (_lastSelection == index) {
@@ -420,11 +421,11 @@ class ListView extends ScrollView implements IDataComponent {
 			_lastSelection = index;
 		}
 	}
-	
+
 	public function isSelected(item:IItemRenderer):Bool {
 		return Lambda.indexOf(_selectedItems, item) != -1;
 	}
-	
+
 	//******************************************************************************************
 	// Helpers
 	//******************************************************************************************
@@ -435,7 +436,7 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 		return index;
 	}
-	
+
 	public function setSelectedIndexNoEvent(value:Int):Int {
 		if (_ready == false) {
 			return value;
@@ -448,7 +449,7 @@ class ListView extends ScrollView implements IDataComponent {
 		}
 		return value;
 	}
-	
+
 	public function ensureVisible(item:IItemRenderer):Void {
 		if (item == null) {
 			return;
@@ -463,13 +464,13 @@ class ListView extends ScrollView implements IDataComponent {
 			_vscroll.pos = item.y;
 		}
 	}
-	
+
 	private function createRendererInstance():IItemRenderer {
 		var r:IItemRenderer = null;
 		if (_itemRenderer == null) {
 			return null;
 		}
-		
+
 		if (Std.is(_itemRenderer, IItemRenderer)) {
 			r = cast(_itemRenderer, IItemRenderer).clone();
 		} else if (Std.is(_itemRenderer, Class)) {
@@ -477,16 +478,16 @@ class ListView extends ScrollView implements IDataComponent {
 			r = Type.createInstance(cls, []);
 		} else if (Std.is(_itemRenderer, String)) {
 			var classString = cast(_itemRenderer, String);
-			var cls:Class<Dynamic> = Type.resolveClass(classString);
+			var cls:Class<Dynamic> = Types.resolveClass(classString);
 			r = Type.createInstance(cls, []);
 		}
-		
+
 		if (r != null) {
 			r.eventDispatcher = this;
 		}
-		
+
 		r.useHandCursor = _allowSelection;
-		
+
 		return r;
 	}
 }

--- a/haxe/ui/toolkit/containers/SpriteContainer.hx
+++ b/haxe/ui/toolkit/containers/SpriteContainer.hx
@@ -4,18 +4,19 @@ import haxe.ui.toolkit.core.Component;
 import haxe.ui.toolkit.core.interfaces.InvalidationFlag;
 import openfl.display.Sprite;
 import haxe.ui.toolkit.core.interfaces.IClonable;
+import haxe.ui.toolkit.util.Types;
 
 class SpriteContainer extends Component implements IClonable<SpriteContainer> {
 	private var _childSprite:Sprite;
 	private var _spriteClass:String;
 	private var _stretch:Bool;
-	
+
 	public function new(childSprite:Sprite = null) {
 		super();
 		this.childSprite = childSprite;
 		autoSize = true;
 	}
-	
+
 	private override function initialize():Void {
 		super.initialize();
 		if (_childSprite != null) {
@@ -27,17 +28,17 @@ class SpriteContainer extends Component implements IClonable<SpriteContainer> {
 			}
 		}
 	}
-	
+
 	public override function dispose():Void {
 		if (_childSprite != null) {
 			sprite.removeChild(_childSprite);
 		}
 		super.dispose();
 	}
-	
+
 	public override function invalidate(type:Int = InvalidationFlag.ALL, recursive:Bool = false):Void {
 		super.invalidate(type, recursive);
-		
+
 		if (type & InvalidationFlag.SIZE == InvalidationFlag.SIZE) {
 			if (_stretch == true && _childSprite != null) {
 				_childSprite.x = layout.padding.left;
@@ -47,13 +48,13 @@ class SpriteContainer extends Component implements IClonable<SpriteContainer> {
 			}
 		}
 	}
-	
+
 	@:clonable
 	public var childSprite(get, set):Sprite;
 	private function get_childSprite():Sprite {
 		return _childSprite;
 	}
-	
+
 	private function set_childSprite(value:Sprite):Sprite {
 		if (value == null && _childSprite != null) {
 			sprite.removeChild(_childSprite);
@@ -74,22 +75,22 @@ class SpriteContainer extends Component implements IClonable<SpriteContainer> {
 		}
 		return value;
 	}
-	
+
 	@:clonable
 	public var spriteClass(get, set):String;
 	private function get_spriteClass():String {
 		return _spriteClass;
 	}
-	
+
 	private function set_spriteClass(value:String):String {
 		if (value == null) {
 			childSprite = null;
 			_spriteClass = null;
 			return value;
 		}
-		
+
 		if (value != _spriteClass) {
-			var cls:Class<Dynamic> = Type.resolveClass(value);
+			var cls:Class<Dynamic> = Types.resolveClass(value);
 			if (cls != null) {
 				var inst:Sprite = Type.createInstance(cls, []);
 				if (inst != null && Std.is(inst, Sprite)) {
@@ -98,16 +99,16 @@ class SpriteContainer extends Component implements IClonable<SpriteContainer> {
 				}
 			}
 		}
-		
+
 		return value;
 	}
-	
+
 	@:clonable
 	public var stretch(get, set):Bool;
 	private function get_stretch():Bool {
 		return _stretch;
 	}
-	
+
 	private function set_stretch(value:Bool):Bool {
 		if (_stretch == value) {
 			return value;

--- a/haxe/ui/toolkit/core/xml/DataProcessor.hx
+++ b/haxe/ui/toolkit/core/xml/DataProcessor.hx
@@ -3,31 +3,32 @@ package haxe.ui.toolkit.core.xml;
 import haxe.ui.toolkit.core.ClassManager;
 import haxe.ui.toolkit.data.DataManager;
 import haxe.ui.toolkit.data.IDataSource;
+import haxe.ui.toolkit.util.Types;
 
 class DataProcessor extends XMLProcessor {
 	public function new() {
 		super();
 	}
-	
+
 	public override function process(node:Xml):Dynamic {
-		var result:Dynamic = null; 
+		var result:Dynamic = null;
 		var nodeName:String = stripNamespace(node.nodeName);
 		nodeName = nodeName.toLowerCase();
-		
+
 		var className:String = ClassManager.instance.getDataSourceClassName(nodeName);
 		if (className != null) {
 			result = createDataSource(className, node);
 		}
 		return result;
 	}
-	
+
 	private static function createDataSource(className:String, config:Xml):IDataSource {
-		var ds:IDataSource = Type.createInstance(Type.resolveClass(className), []);
+		var ds:IDataSource = Type.createInstance(Types.resolveClass(className), []);
 		if (ds != null) {
 			ds.create(config);
 			DataManager.instance.registerDataSource(ds);
 		};
-		
+
 		return ds;
 	}
 }

--- a/haxe/ui/toolkit/core/xml/UIProcessor.hx
+++ b/haxe/ui/toolkit/core/xml/UIProcessor.hx
@@ -20,6 +20,7 @@ import haxe.ui.toolkit.layout.VerticalLayout;
 import haxe.ui.toolkit.style.Style;
 import haxe.ui.toolkit.style.StyleParser;
 import haxe.ui.toolkit.style.Styles;
+import haxe.ui.toolkit.util.Types;
 import haxe.ui.toolkit.util.TypeParser;
 
 class UIProcessor extends XMLProcessor {
@@ -35,7 +36,7 @@ class UIProcessor extends XMLProcessor {
 			nodeName = nodeName.substr(n + 1, nodeName.length);
 		}
 		nodeName = nodeName.toLowerCase();
-		
+
 		var className:String = ClassManager.instance.getComponentClassName(nodeName);
 		var direction:String = node.get("direction");
 		if (direction != null) {
@@ -51,20 +52,20 @@ class UIProcessor extends XMLProcessor {
 		}
 		return result;
 	}
-	
+
 	private static function createComponent(className, config:Xml):IDisplayObject {
-		var c:Component = Type.createInstance(Type.resolveClass(className), []);
+		var c:Component = Type.createInstance(Types.resolveClass(className), []);
 
 		for (attr in config.attributes()) {
 			if (StringTools.startsWith(attr, "xmlns:")) {
 				continue;
 			}
-			
+
 			var value:String = config.get(attr);
 			if (ScriptUtils.isScript(value)) {
 				value = ScriptManager.instance.executeScript(value);
 			}
-			
+
 			if (attr == "width") { // special case for width, want to be able to specify % values
 				var width:Float = 0;
 				var percentWidth:Float = -1;
@@ -76,7 +77,7 @@ class UIProcessor extends XMLProcessor {
 						percentWidth = Std.parseFloat(widthString.substr(0, widthString.length - 1));
 					}
 				}
-				
+
 				if (width != 0) {
 					c.width = width;
 				}
@@ -94,7 +95,7 @@ class UIProcessor extends XMLProcessor {
 						percentHeight = Std.parseFloat(heightString.substr(0, heightString.length - 1));
 					}
 				}
-				
+
 				if (height != 0) {
 					c.height = height;
 				}
@@ -136,7 +137,7 @@ class UIProcessor extends XMLProcessor {
 							var proto:String = value.substr(0, n);
 							value = value.substr(n + 3, value.length);
 							var className:String = ClassManager.instance.getDataSourceClassName(proto);
-							var ds:IDataSource = Type.createInstance(Type.resolveClass(className), []);
+							var ds:IDataSource = Type.createInstance(Types.resolveClass(className), []);
 							if (ds != null) {
 								ds.createFromResource(value);
 								DataManager.instance.registerDataSource(ds);
@@ -168,7 +169,7 @@ class UIProcessor extends XMLProcessor {
 				}
 			}
 		}
-		
+
 		return c;
 	}
 }

--- a/haxe/ui/toolkit/util/Types.hx
+++ b/haxe/ui/toolkit/util/Types.hx
@@ -1,0 +1,15 @@
+package haxe.ui.toolkit.util;
+
+class Types {
+
+	/**
+	 * @param className name of the class to resolve
+	 * @return the corresponding class instance
+	 * @throws an exception in case the class could not be found
+	 */
+	public static function resolveClass(className): Class<Dynamic> {
+		var clazz = Type.resolveClass(className);
+		if (clazz == null) throw 'Cannot find class with name [$className]';
+		return clazz;
+	}
+}


### PR DESCRIPTION
Instead of such an obscure exception

    $nargs
    Called from Type::createInstance line 102
    Called from haxe.ui.toolkit.core.xml.UIProcessor::createComponent line 57
    Called from haxe.ui.toolkit.core.xml.UIProcessor::process line 51
    Called from haxe.ui.toolkit.core.Toolkit::processXmlNode line 187

a meaning full exception will be thrown:

    Cannot find class with name [haxe.ui.toolkit.containers.Absolute]
    Called from haxe.ui.toolkit.util.Types::resolveClass line 12
    Called from haxe.ui.toolkit.core.xml.UIProcessor::createComponent line 57
    Called from haxe.ui.toolkit.core.xml.UIProcessor::process line 51
    Called from haxe.ui.toolkit.core.Toolkit::processXmlNode line 187

This is especially important when troubleshooting DCE issues as reported in #283