### PR TITLE
fixed: toggling selected on a Button could put it in a weird state (particularly on mobile)

### DIFF
--- a/haxe/ui/toolkit/controls/Button.hx
+++ b/haxe/ui/toolkit/controls/Button.hx
@@ -442,6 +442,8 @@ class Button extends StateComponent implements IFocusable implements IClonable<S
 		super.set_state(value);
 		if (value == STATE_DOWN) {
 			_down = true;
+		} else {
+			_down = false;
 		}
 		return value;
 	}


### PR DESCRIPTION
Once a non-selectable button had been marked as selected and then non-selected, it retained its _down state, causing it respond to mouseover+down events, even though it was non-selectable.

In the case of mobile devices this made non-selectable buttons respond to taps, once they had been toggled once, even when non-selectable.