### PR TITLE
added: scrollStart and scrollStop events

### DIFF
--- a/haxe/ui/toolkit/containers/ScrollView.hx
+++ b/haxe/ui/toolkit/containers/ScrollView.hx
@@ -425,6 +425,7 @@ class ScrollView extends StateComponent {
 				_downPos = new Point(event.stageX, event.stageY);
 				Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 				Screen.instance.addEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 			}
 		}
 		
@@ -432,6 +433,7 @@ class ScrollView extends StateComponent {
 			_downPos = new Point(event.stageX, event.stageY);
 			Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 			Screen.instance.addEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
+			dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		}
 	}
 	
@@ -500,6 +502,8 @@ class ScrollView extends StateComponent {
 		if (_vscroll != null && _showVScroll == true && _autoHideScrolls == true) {
 			_vscroll.visible = false;
 		}
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
 	}
 	
 	//******************************************************************************************
@@ -598,6 +602,12 @@ class ScrollView extends StateComponent {
 			_hscroll.id = "hscroll";
 			_hscroll.percentWidth = 100;
 			_hscroll.addEventListener(Event.CHANGE, _onHScrollChange);
+			_hscroll.addEventListener(UIEvent.SCROLL_START, function(event):Void {
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
+			});
+			_hscroll.addEventListener(UIEvent.SCROLL_STOP, function(event):Void {
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+			});
 			if (_showHScroll == false) {
 				_hscroll.visible = false;
 			} else if (_autoHideScrolls == true) {
@@ -627,6 +637,12 @@ class ScrollView extends StateComponent {
 			_vscroll.id = "vscroll";
 			_vscroll.percentHeight = 100;
 			_vscroll.addEventListener(Event.CHANGE, _onVScrollChange);
+			_vscroll.addEventListener(UIEvent.SCROLL_START, function(event):Void {
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
+			});
+			_vscroll.addEventListener(UIEvent.SCROLL_STOP, function(event):Void {
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+			});
 			if (_showVScroll == false) {
 				_vscroll.visible = false;
 			} else if (_autoHideScrolls == true) {

--- a/haxe/ui/toolkit/controls/HScroll.hx
+++ b/haxe/ui/toolkit/controls/HScroll.hx
@@ -10,6 +10,7 @@ import haxe.ui.toolkit.core.interfaces.IDisplayObject;
 import haxe.ui.toolkit.core.interfaces.InvalidationFlag;
 import haxe.ui.toolkit.core.interfaces.IScrollable;
 import haxe.ui.toolkit.core.Screen;
+import haxe.ui.toolkit.events.UIEvent;
 import haxe.ui.toolkit.layout.DefaultLayout;
 
 /**
@@ -98,6 +99,8 @@ class HScroll extends Scroll implements IScrollable implements IClonable<HScroll
 
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 		Screen.instance.addEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		
 		event.stopImmediatePropagation();
 		event.stopPropagation();
@@ -132,11 +135,15 @@ class HScroll extends Scroll implements IScrollable implements IClonable<HScroll
 		if (_scrollTimer != null) {
 			_scrollTimer.stop();
 		}
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+
 		Screen.instance.removeEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 		Screen.instance.removeEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
 	}
 	
 	private function _onDeinc(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		deincrementValue();
 		_scrollDirection = 0;
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
@@ -152,6 +159,7 @@ class HScroll extends Scroll implements IScrollable implements IClonable<HScroll
 	}
 	
 	private function _onInc(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		incrementValue();
 		_scrollDirection = 1;
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
@@ -179,11 +187,14 @@ class HScroll extends Scroll implements IScrollable implements IClonable<HScroll
 	}
 	
 	private function _onMouseDown(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
+
 		if (event.localX > _thumb.x) { // page down
 			pos += pageSize;
 		} else { // page up
 			pos -= pageSize;
 		}
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
 	}
 	
 	//******************************************************************************************
@@ -228,8 +239,8 @@ class HScroll extends Scroll implements IScrollable implements IClonable<HScroll
 		}
 		if (value != _pos) {
 			_pos = value;
-			var changeEvent:Event = new Event(Event.CHANGE);
-			dispatchEvent(changeEvent);
+			dispatchEvent(new Event(Event.CHANGE));
+			dispatchEvent(new UIEvent(UIEvent.SCROLL));
 			invalidate(InvalidationFlag.LAYOUT);
 		}
 		return value;

--- a/haxe/ui/toolkit/controls/VScroll.hx
+++ b/haxe/ui/toolkit/controls/VScroll.hx
@@ -10,6 +10,7 @@ import haxe.ui.toolkit.core.interfaces.IDisplayObject;
 import haxe.ui.toolkit.core.interfaces.InvalidationFlag;
 import haxe.ui.toolkit.core.interfaces.IScrollable;
 import haxe.ui.toolkit.core.Screen;
+import haxe.ui.toolkit.events.UIEvent;
 import haxe.ui.toolkit.layout.DefaultLayout;
 
 /**
@@ -98,6 +99,8 @@ class VScroll extends Scroll implements IScrollable implements IClonable<VScroll
 
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 		Screen.instance.addEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		
 		event.stopImmediatePropagation();
 		event.stopPropagation();
@@ -132,11 +135,15 @@ class VScroll extends Scroll implements IScrollable implements IClonable<VScroll
 		if (_scrollTimer != null) {
 			_scrollTimer.stop();
 		}
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+
 		Screen.instance.removeEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
 		Screen.instance.removeEventListener(MouseEvent.MOUSE_MOVE, _onScreenMouseMove);
 	}
 	
 	private function _onDeinc(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		deincrementValue();
 		_scrollDirection = 0;
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
@@ -152,6 +159,7 @@ class VScroll extends Scroll implements IScrollable implements IClonable<VScroll
 	}
 	
 	private function _onInc(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
 		incrementValue();
 		_scrollDirection = 1;
 		Screen.instance.addEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
@@ -179,11 +187,15 @@ class VScroll extends Scroll implements IScrollable implements IClonable<VScroll
 	}
 	
 	private function _onMouseDown(event:MouseEvent):Void {
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_START));
+
 		if (event.localY > _thumb.y) { // page down
 			pos += pageSize;
 		} else { // page up
 			pos -= pageSize;
 		}
+
+		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
 	}
 	
 	//******************************************************************************************
@@ -228,8 +240,8 @@ class VScroll extends Scroll implements IScrollable implements IClonable<VScroll
 		}
 		if (value != _pos) {
 			_pos = value;
-			var changeEvent:Event = new Event(Event.CHANGE);
-			dispatchEvent(changeEvent);
+			dispatchEvent(new Event(Event.CHANGE));
+			dispatchEvent(new UIEvent(UIEvent.SCROLL));
 			invalidate(InvalidationFlag.LAYOUT);
 		}
 		return value;

--- a/haxe/ui/toolkit/core/DisplayObject.hx
+++ b/haxe/ui/toolkit/core/DisplayObject.hx
@@ -16,8 +16,9 @@ import haxe.ui.toolkit.util.StringUtil;
 
 @:build(haxe.ui.toolkit.core.Macros.addEvents([
 	"init", "resize", "ready",
-	"click", "mouseDown", "mouseUp", "mouseOver", "mouseOut", "mouseMove", "doubleClick", "rollOver", "rollOut", "change", "scroll", 
+	"click", "mouseDown", "mouseUp", "mouseOver", "mouseOut", "mouseMove", "doubleClick", "rollOver", "rollOut", "change",
 	"added", "addedToStage", "removed", "removedFromStage", "activate", "deactivate",
+	"scroll", "scrollStart", "scrollStop",
 	"glyphClick",
 	"menuSelect", "menuOpen"
 ]))
@@ -28,6 +29,9 @@ import haxe.ui.toolkit.util.StringUtil;
 @:event("UIEvent.ADDED_TO_STAGE", "Dispatched when a display object is added to the on stage display list")
 @:event("UIEvent.REMOVED_FROM_STAGE", "Dispatched when a display object is about to be removed from the display list")
 @:event("UIEvent.RESIZE", "Dispatched when the display object has been resized")
+@:event("UIEvent.SCROLL", "Dispatched every time the scroll position changes")
+@:event("UIEvent.SCROLL_START", "Dispatched when the user begins scrolling")
+@:event("UIEvent.SCROLL_STOP", "Dispatched when the user stops scrolling")
 class DisplayObject implements IEventDispatcher implements IDisplayObject implements IDrawable implements IClonable<DisplayObject> {
 	// used in IDisplayObject getters/setters
 	private var _parent:IDisplayObjectContainer;

--- a/haxe/ui/toolkit/events/UIEvent.hx
+++ b/haxe/ui/toolkit/events/UIEvent.hx
@@ -22,6 +22,8 @@ class UIEvent extends Event {
 	public static inline var ROLL_OUT:String = PREFIX + "rollOut";
 	public static inline var CHANGE:String = PREFIX + "change";
 	public static inline var SCROLL:String = PREFIX + "scroll";
+	public static inline var SCROLL_START:String = PREFIX + "scrollStart";
+	public static inline var SCROLL_STOP:String = PREFIX + "scrollStop";
 
 	public static inline var ADDED:String = PREFIX + "added";
 	public static inline var ADDED_TO_STAGE:String = PREFIX + "addedToStage";


### PR DESCRIPTION
HScrolls, VScrolls and ScrollViews now emit `scrollStart` and `scrollStop` events when a scroll begins and finally ends (so `scrollStop` fires when the mouse/finger/device is released).

Useful for if you need the ui to perform snapping or adjustments after a user has halted interaction.

For conformity HScrolls and VScrolls now emit `scroll` events as well as `change` events, as they are adjusted.