### PR TITLE
fixed: runtime comma-separated styles were linked

### DIFF
--- a/haxe/ui/toolkit/style/StyleParser.hx
+++ b/haxe/ui/toolkit/style/StyleParser.hx
@@ -119,7 +119,7 @@ class StyleParser {
 				var arr:Array<String> = styleName.split(",");
 				for (s in arr) {
 					s = StringTools.trim(s);
-					styles.addStyle(s, style);
+					styles.addStyle(s, style.clone());
 				}
 			}
 			


### PR DESCRIPTION
Using a style selector like `".stylea, .styleb"` and then adding a second style affecting just `stylea` would also affect `styleb` as they were linked to the same instance