### PR TITLE
The Disabled property doesn't work properly if it was assigned twice.

### DIFF
--- a/haxe/ui/toolkit/core/Component.hx
+++ b/haxe/ui/toolkit/core/Component.hx
@@ -136,6 +136,9 @@ class Component extends StyleableDisplayObject implements IComponent implements 
 	}
 	
 	private function set_disabled(value:Bool):Bool {
+        if(_disabled == value)
+            return value;
+
 		if (value == true) {
 			if (_cachedListeners == null) {
 				_cachedListeners = new StringMap < Array < Dynamic->Void >> ();


### PR DESCRIPTION
Hi.

You can't assign the disabled property twice because a listener is lost in the next time. 

Here a simple example:

```
Toolkit.openFullscreen(function(root:Root) {
            var button = new Button();
            button.width = 100;
            button.height = 50;
            button.text = "Click Me";
            button.addEventListener(UIEvent.CLICK, function(e:UIEvent){
                trace("Click 1");
            });
            button.addEventListener(UIEvent.CLICK, function(e:UIEvent){
                trace("Click 2");
            });

            button.disabled = true;
            button.disabled = true;   //The problem
            button.disabled = false;
            root.addChild(button);
        });
```

I have implemented a simple check if disabled == value to avoid unnecesary work.

Kind Regards.