### PR TITLE
Update ScriptManager.hx

### DIFF
--- a/haxe/ui/toolkit/hscript/ScriptManager.hx
+++ b/haxe/ui/toolkit/hscript/ScriptManager.hx
@@ -34,16 +34,20 @@ class ScriptManager {
 	}
 	
 	public function executeScript<T>(script:String):Null<T> {
-		var fullScript:String = "";
-		fullScript += script;
+		if(script == null) return null;
 		var retVal = null;
 		
 		try {
 			var parser = new hscript.Parser();
-			var program = parser.parseString(fullScript);
+			var program = parser.parseString(script);
 			var interp = new ScriptInterp();
 			
 			retVal = interp.execute(program);
+			
+			#if (cpp && haxe_ver >= 3.5)
+			    // workaround for https://github.com/HaxeFoundation/hxcpp/issues/489
+			    if (retVal == null) retVal = cast script;
+			#end
 		} catch (e:Dynamic) {
 			//trace("Problem running script: " + e);
 			//trace(script);


### PR DESCRIPTION
a) Workaround for https://github.com/HaxeFoundation/hxcpp/issues/489 which crashes HaxeUI apps if a dash - is used within CSS attribute fields:
HaxeUIApp.hx:151: Exception uncaughtError: Null Object Reference
 at DocumentClass.new (ApplicationMain.hx:214)
 at Type.createInstance (Type.hx:83)
 at ApplicationMain.main (ApplicationMain.hx:116)

b) prevent unnecessary creation of new String object on each script execution.