### PR TITLE
Fix scroll stop event

### DIFF
--- a/haxe/ui/toolkit/containers/ScrollView.hx
+++ b/haxe/ui/toolkit/containers/ScrollView.hx
@@ -390,8 +390,8 @@ class ScrollView extends StateComponent {
 					_vscroll.visible = false;
 				}
 				Screen.instance.removeEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
-                dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
-            }
+				dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+			}
 		}
 	}
 	
@@ -583,11 +583,11 @@ class ScrollView extends StateComponent {
 			_vscroll.visible = false;
 		}
 
-        if ( _inertialScrolling == true && ( Lib.getTimer() - _inertiaTime ) < 100
-            && ( Math.abs(_inertiaSpeed.x) > _inertiaSensitivity || Math.abs(_inertiaSpeed.y) > _inertiaSensitivity ) )
-                Screen.instance.addEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
-        else
-		    dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+		if ( _inertialScrolling == true && ( Lib.getTimer() - _inertiaTime ) < 100
+			&& ( Math.abs(_inertiaSpeed.x) > _inertiaSensitivity || Math.abs(_inertiaSpeed.y) > _inertiaSensitivity ) )
+				Screen.instance.addEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
+		else
+			dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
 		
 		if (_pulling == true && _refreshPromptView != null) {
 			if (_refreshPromptView.alpha < 1) {

--- a/haxe/ui/toolkit/containers/ScrollView.hx
+++ b/haxe/ui/toolkit/containers/ScrollView.hx
@@ -390,7 +390,8 @@ class ScrollView extends StateComponent {
 					_vscroll.visible = false;
 				}
 				Screen.instance.removeEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
-			}
+                dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+            }
 		}
 	}
 	
@@ -570,11 +571,6 @@ class ScrollView extends StateComponent {
 	
 	private function _onScreenMouseUp(event:MouseEvent):Void {
 
-		if ( _inertialScrolling == true && ( Lib.getTimer() - _inertiaTime ) < 100 ) {
-			if ( Math.abs(_inertiaSpeed.x) > _inertiaSensitivity || Math.abs(_inertiaSpeed.y) > _inertiaSensitivity )
-				Screen.instance.addEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
-		}
-
 		_eventTarget.visible = false;
 		_downPos = null;
 		Screen.instance.removeEventListener(MouseEvent.MOUSE_UP, _onScreenMouseUp);
@@ -587,7 +583,11 @@ class ScrollView extends StateComponent {
 			_vscroll.visible = false;
 		}
 
-		dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
+        if ( _inertialScrolling == true && ( Lib.getTimer() - _inertiaTime ) < 100
+            && ( Math.abs(_inertiaSpeed.x) > _inertiaSensitivity || Math.abs(_inertiaSpeed.y) > _inertiaSensitivity ) )
+                Screen.instance.addEventListener(Event.ENTER_FRAME, _onInertiaEnterFrame);
+        else
+		    dispatchEvent(new UIEvent(UIEvent.SCROLL_STOP));
 		
 		if (_pulling == true && _refreshPromptView != null) {
 			if (_refreshPromptView.alpha < 1) {


### PR DESCRIPTION
The "SCROLL_STOP" event should dispatch when the inertia is finished.

For example, you have a list of thumbnails and you want to load the thumbnails in screen when the SCROLL_STOP is dispatched.